### PR TITLE
ci: add MSRV support as compiler target

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,11 @@
-msrv = "1.63.0"
+# .clippy.toml is a configuration file to configure different types of
+# Clippy lints. Please note that through this file:
+#  - it is only possible to configure the behavior of lints
+#  - it is not possible to add new lints, or allow/deny lints
+#
+# To run Clippy, run: `cargo clippy`
+#
+# Further readings:
+#  - Repository: https://github.com/rust-lang/rust-clippy
+#  - Documentation: https://rust-lang.github.io/rust-clippy/master/index.html
+#  - Allowing/denying lints: https://github.com/rust-lang/rust-clippy#allowingdenying-lints

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,14 +27,23 @@ on:
 
 jobs:
   build:
-    name: build
+    name: build (${{ matrix.label }})
     runs-on: ubuntu-latest
     strategy:
+      # Documentation:
+      #  - https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
+      #  - https://rust-lang.github.io/rustup/concepts/channels.html
+      #  - https://rust-lang.github.io/rustup/concepts/toolchains.html
       matrix:
-        toolchain:
-          - stable
-          - beta
-          - nightly
+        include:
+          - label: msrv
+            toolchain: '1.70'
+          - label: stable
+            toolchain: stable
+          - label: beta
+            toolchain: beta
+          - label: nightly
+            toolchain: nightly
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,13 @@ jobs:
         rustup toolchain install stable
         rustup override set stable
         rustup component add llvm-tools-preview
+    - name: Print environment info
+      run: |
+        rustc --version --verbose
+        cargo --version
+        cargo clippy --version
+        cargo fmt --version
+        rustup --version
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,8 +57,6 @@ jobs:
       run: |
         rustc --version --verbose
         cargo --version
-        cargo clippy --version
-        cargo fmt --version
         rustup --version
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
@@ -81,6 +79,11 @@ jobs:
         rustup toolchain install stable
         rustup override set stable
         rustup component add llvm-tools-preview
+    - name: Print environment info
+      run: |
+        rustc --version --verbose
+        cargo --version
+        rustup --version
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:
@@ -109,6 +112,11 @@ jobs:
         rustup set profile minimal
         rustup toolchain install stable
         rustup override set stable
+    - name: Print environment info
+      run: |
+        rustc --version --verbose
+        cargo --version
+        rustup --version
     - name: Install Valgrind
       run: sudo apt install -y valgrind
     - name: Run benchmarks
@@ -128,6 +136,12 @@ jobs:
           rustup toolchain install stable
           rustup override set stable
           rustup component add rustfmt
+      - name: Print environment info
+        run: |
+          rustc --version --verbose
+          cargo --version
+          cargo fmt --version
+          rustup --version
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
@@ -149,6 +163,12 @@ jobs:
           rustup toolchain install stable
           rustup override set stable
           rustup component add clippy
+      - name: Print environment info
+        run: |
+          rustc --version --verbose
+          cargo --version
+          cargo clippy --version
+          rustup --version
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,13 @@ jobs:
         rustup set profile minimal
         rustup toolchain install ${{ matrix.toolchain }}
         rustup override set ${{ matrix.toolchain }}
+    - name: Print environment info
+      run: |
+        rustc --version --verbose
+        cargo --version
+        cargo clippy --version
+        cargo fmt --version
+        rustup --version
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:
@@ -74,13 +81,6 @@ jobs:
         rustup toolchain install stable
         rustup override set stable
         rustup component add llvm-tools-preview
-    - name: Print environment info
-      run: |
-        rustc --version --verbose
-        cargo --version
-        cargo clippy --version
-        cargo fmt --version
-        rustup --version
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-    - name: Install Rust
+    - name: Install Rust (${{ matrix.toolchain }})
       run: |
         rustup set profile minimal
         rustup toolchain install ${{ matrix.toolchain }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "Your description of the Rust library"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.70.0"
 # keywords = []
 # categories = []
 exclude = [


### PR DESCRIPTION
 - GitHub Actions CI will now automatically compile against minimum-supported Rust version (MSRV)
 - MSRV is no longer configured .clippy.toml. It is now configured instead inside `Cargo.toml`, `.github/workflows/main.yml`
 - Add documentation to `.clippy.toml` file within