### PR TITLE
chore: setup Dependabot for /fuzz directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,17 @@ updates:
       - "pkg-cargo"
     open-pull-requests-limit: 4
 
+  - package-ecosystem: "cargo"
+    directory: "/fuzz"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps/cargo):"
+    labels:
+      - "t-dependencies"
+      - "pkg-cargo"
+    open-pull-requests-limit: 4
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "rust-template-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true


### PR DESCRIPTION
 - use 2021 edition instead of 2018 edition